### PR TITLE
Fix wrapper/variant class conflicts on React Aria trigger buttons

### DIFF
--- a/registry/aria/ui/AlertDialog.res
+++ b/registry/aria/ui/AlertDialog.res
@@ -234,7 +234,7 @@ module Cancel = {
     ~type_=?,
     ~ariaLabel=?,
   ) => {
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick

--- a/registry/aria/ui/Button.res
+++ b/registry/aria/ui/Button.res
@@ -90,3 +90,33 @@ let make = (props: props) => {
     <ReactAria.Button {...props->toAriaProps} dataSlot className />
   }
 }
+
+module Primitive = {
+  type props = {
+    ...ReactAria.Types.BaseUIComponentProps.t,
+    ...ReactAria.Types.NativeButtonProps.t,
+    focusableWhenDisabled?: bool,
+  }
+
+  let toAriaProps: props => ReactAria.Button.props = %raw(`props => {
+    const {disabled, nativeButton, render, focusableWhenDisabled, onClick, ...rest} = props;
+    return {...rest, isDisabled: disabled, allowFocusWhenDisabled: focusableWhenDisabled, onPress: onClick};
+  }`)
+
+  let toDomProps: props => ReactAria.Types.BaseUIComponentProps.t = %raw(`props => {
+    const {nativeButton, focusableWhenDisabled, render, ...rest} = props;
+    return rest;
+  }`)
+
+  @react.componentWithProps(props)
+  let make = (props: props) =>
+    switch props.render {
+    | Some(render) =>
+      Render.use({
+        render,
+        defaultTagName: "button",
+        props: props->toDomProps,
+      })
+    | None => <ReactAria.Button {...props->toAriaProps} />
+    }
+}

--- a/registry/aria/ui/Combobox.res
+++ b/registry/aria/ui/Combobox.res
@@ -100,7 +100,7 @@ module Trigger = {
     ~ariaLabel=?,
     ~tabIndex=?,
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick
@@ -116,7 +116,7 @@ module Trigger = {
     >
       {children}
       <Icons.ChevronDown className="cn-combobox-trigger-icon pointer-events-none" />
-    </Button>
+    </Button.Primitive>
 }
 
 module Clear = {

--- a/registry/aria/ui/ContextMenu.res
+++ b/registry/aria/ui/ContextMenu.res
@@ -43,7 +43,7 @@ module Trigger = {
     ~onClick=?,
     ~onKeyDown=?,
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?disabled

--- a/registry/aria/ui/Dialog.res
+++ b/registry/aria/ui/Dialog.res
@@ -32,7 +32,7 @@ module Trigger = {
     ~ariaLabel=?,
     ~dataSlot="dialog-trigger",
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick
@@ -69,7 +69,7 @@ module Close = {
     ~ariaLabel=?,
     ~dataSlot="dialog-close",
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick

--- a/registry/aria/ui/DropdownMenu.res
+++ b/registry/aria/ui/DropdownMenu.res
@@ -31,9 +31,9 @@ module Portal = {
 }
 
 module Trigger = {
-  @react.componentWithProps(Button.props)
-  let make = (props: Button.props) =>
-    <Button {...props} dataSlot="dropdown-menu-trigger" />
+  @react.componentWithProps(Button.Primitive.props)
+  let make = (props: Button.Primitive.props) =>
+    <Button.Primitive {...props} dataSlot="dropdown-menu-trigger" />
 }
 
 module Content = {

--- a/registry/aria/ui/Popover.res
+++ b/registry/aria/ui/Popover.res
@@ -22,9 +22,9 @@ let make = (
   }
 
 module Trigger = {
-  @react.componentWithProps(Button.props)
-  let make = (props: Button.props) =>
-    <Button {...props} dataSlot={props.dataSlot->Option.getOr("popover-trigger")} />
+  @react.componentWithProps(Button.Primitive.props)
+  let make = (props: Button.Primitive.props) =>
+    <Button.Primitive {...props} dataSlot={props.dataSlot->Option.getOr("popover-trigger")} />
 }
 
 module Content = {

--- a/registry/aria/ui/Sheet.res
+++ b/registry/aria/ui/Sheet.res
@@ -33,7 +33,7 @@ module Trigger = {
     ~type_=?,
     ~ariaLabel=?,
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick
@@ -64,7 +64,7 @@ module Close = {
     ~type_=?,
     ~ariaLabel=?,
   ) =>
-    <Button
+    <Button.Primitive
       ?id
       ?style
       ?onClick

--- a/registry/aria/ui/Tooltip.res
+++ b/registry/aria/ui/Tooltip.res
@@ -55,7 +55,7 @@ module Trigger = {
     ~render=?,
     ~style=?,
   ) =>
-    <Button
+    <Button.Primitive
       ?className
       ?children
       ?id


### PR DESCRIPTION
## Problem

Some trigger and close buttons in the React Aria components were rendered through the styled `Button`, so the wrapper's classes and the rendered button's own variant classes ended up combined. This produced buttons with the wrong expected classes. 

I could only see this issue on React Aria components, the Base UI ones seem good (they render these buttons as plain `<button />` tag.

## Fix

Adds an unstyled `Button.Primitive` for cases like this, avoiding the conflict between the variant styles and the wrapper styles.

## Screenshots

| Before | After |
|---|---|
| <img width="865" height="498" alt="image" src="https://github.com/user-attachments/assets/0858bfcb-5496-46fa-8eba-3c7900445e88" /> | <img width="921" height="527" alt="image" src="https://github.com/user-attachments/assets/ee46eeb0-8156-4a54-a6bb-80373873e831" /> |
| <img width="879" height="524" alt="image" src="https://github.com/user-attachments/assets/1f4803d2-6d85-4d3b-a56e-101ea55e4394" /> | <img width="877" height="563" alt="image" src="https://github.com/user-attachments/assets/f77adeb3-6b13-4fa6-924c-ca1c80db7f9f" /> |